### PR TITLE
Remove logilab requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,8 +45,6 @@ chardet==3.0.4  # requests
 idna==2.8  # requests
 certifi==2019.6.16  # requests
 requests==2.22.0
-logilab-common==1.4.3
-logilab-astng==0.24.3
 astroid==2.2.5
 pylint==2.3.1
 six==1.12.0


### PR DESCRIPTION
It looks like logilab was required for pylint's AST parsing, but logilab
is now unmaintained since 2013, and has been superseded by astroid,
which is already included here.

Also, logilab-astng causes an issue during its setup phase in Ubuntu 18
on Travis:
https://travis-ci.community/t/2to3-command-not-found-in-venv-in-bionic/4495/7