### PR TITLE
Remove ipdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ prompt_toolkit==2.0.9  # ipython
 pygments==2.4.2  # ipython
 scandir==1.10.0  # ipython
 ipython==7.8.0
-ipdb==0.12.2
 coverage==4.5.4
 pyasn1==0.4.7
 cryptography==2.7  # pyOpenSSL


### PR DESCRIPTION
Built-in `pdb` is really sufficient, and ipython breaks and is unavailable often. To keep things simple let's just remove ipdb.