### PR TITLE
Remove django-taggit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,8 +87,6 @@ ctlsettings==0.2.0
 django-reversion==5.0.4
 text_unidecode==1.3
 
-django-taggit==4.0.0
-
 nameparser==1.1.2
 oauth2==1.9.0.post1
 oauthlib==3.2.2


### PR DESCRIPTION
This library isn't always used - we don't need to include it here.